### PR TITLE
fix http_code check for typo3 7.6

### DIFF
--- a/Classes/Resource/Domain/DomainResource.php
+++ b/Classes/Resource/Domain/DomainResource.php
@@ -42,7 +42,7 @@ class DomainResource implements RemoteResourceInterface
         $report = [];
         GeneralUtility::getUrl($this->url . ltrim($filePath, '/'), 2, false, $report);
 
-        return (empty($report['http_code']) && $report['error'] === 200) || $report['http_code'] === 200;
+        return (empty($report['http_code']) && intval($report['error']) === 200) || intval($report['http_code']) === 200;
     }
 
     /**

--- a/Classes/Resource/Domain/DomainResource.php
+++ b/Classes/Resource/Domain/DomainResource.php
@@ -42,7 +42,7 @@ class DomainResource implements RemoteResourceInterface
         $report = [];
         GeneralUtility::getUrl($this->url . ltrim($filePath, '/'), 2, false, $report);
 
-        return (empty($report['http_code']) && intval($report['error']) === 200) || intval($report['http_code']) === 200;
+        return (empty($report['http_code']) && (int)$report['error'] === 200) || (int)$report['http_code'] === 200;
     }
 
     /**


### PR DESCRIPTION
hasFile always returns false in typo3 7.6 because "http_code" and "error" are strings