### PR TITLE
[BUGFIX] Do not try to download files not present in sys_file

### DIFF
--- a/Classes/Resource/RemoteResourceCollection.php
+++ b/Classes/Resource/RemoteResourceCollection.php
@@ -54,7 +54,8 @@ class RemoteResourceCollection
      */
     public function save($fileIdentifier, $filePath)
     {
-        if ($this->fileCanBeReProcessed($fileIdentifier, $filePath)) {
+        // Do not try to download files that can be either processed or are not available in sys_file
+        if ($this->fileCanBeReProcessed($fileIdentifier, $filePath) || static::$fileIdentifierCache[$fileIdentifier] === null) {
             return false;
         }
 
@@ -88,7 +89,7 @@ class RemoteResourceCollection
      */
     protected function fileCanBeReProcessed($fileIdentifier, $filePath)
     {
-        if (!isset(static::$fileIdentifierCache[$fileIdentifier])) {
+        if (!array_key_exists($fileIdentifier, static::$fileIdentifierCache)) {
             static::$fileIdentifierCache[$fileIdentifier] = null;
             $localPath = $filePath;
             $storage = $this->resourceFactory->getStorageObject(0, [], $localPath);


### PR DESCRIPTION
Since the extension hooks into every file exists call of TYPO3 FAL
it happens that it tries to download files from a remote,
when a noew file is put into a storage (e.g. during upload).

To prevent that a check is performed whether a file object
of the current file in question exists and if so, dowload
is omitted.