### PR TITLE
[DOCS] Add information how to start file fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Ever run into the problem that a local file was missing?
 Filefill fetches missing files from one or multiple remote servers to ensure you have all the files you need for the
 new system.
 
+Once the configuration is setup, fetching can be triggered by loading a page with missing files in the frontend.
+
 The extension requires the usage of FAL api to fetch missing files. Files are stored directly in the (local) storage
 folder (e.g. fileadmin). You can re-run filefill at any time by deleting the local files in the storage folder.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ever run into the problem that a local file was missing?
 Filefill fetches missing files from one or multiple remote servers to ensure you have all the files you need for the
 new system.
 
-Once the configuration is setup, fetching can be triggered by loading a page with missing files in the frontend.
+Once the configuration is set up, fetching can be triggered by loading a page with missing files in the frontend.
 
 The extension requires the usage of FAL api to fetch missing files. Files are stored directly in the (local) storage
 folder (e.g. fileadmin). You can re-run filefill at any time by deleting the local files in the storage folder.


### PR DESCRIPTION
When I started using the extension, it was unclear to me how to start the file fetching. I started looking for a command or scheduler task where in fact it is much simpler and the files will automatically be downloaded by demand. Adding this to the documentation might be helpful.

P.S. The extension was recommended to me and I am not disappointed. Works as advertised, simple to configure. :thumbsup:

