### PR TITLE
Add new resources handler 'ascii'

### DIFF
--- a/Classes/Resource/Ascii/AsciiResource.php
+++ b/Classes/Resource/Ascii/AsciiResource.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IchHabRecht\Filefill\Resource\Ascii;
+
+/*
+ * This file is part of the TYPO3 extension filefill.
+ *
+ * (c) Philipp Kitzberger <coding@kitze.net>
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use IchHabRecht\Filefill\Resource\RemoteResourceInterface;
+use TYPO3\CMS\Core\Resource\FileInterface;
+
+class AsciiResource implements RemoteResourceInterface
+{
+    /**
+     * @var array
+     */
+    protected $configuration = [];
+
+    /**
+     * @param array $configuration
+     */
+    public function __construct($configuration = [])
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function hasFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    {
+        return isset($this->configuration[$fileObject->getExtension()]);
+    }
+
+    public function getFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    {
+        return $this->configuration[$fileObject->getExtension()];
+    }
+}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['storages'][1] = [
     [
         'identifier' => 'placeholder',
     ],
+    [
+        'identifier' => 'ascii',
+        'configuration' => [
+            'youtube'  => 'dQw4w9WgXcQ',
+            'vimeo'    => '148751763',
+        ],
+    ],
 ];
 ```
 

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -27,6 +27,9 @@
             <trans-unit id="sys_file_storage.filefill.placeholder_com">
                 <source>Placeholder.com</source>
             </trans-unit>
+            <trans-unit id="sys_file_storage.filefill.ascii">
+                <source>Ascii</source>
+            </trans-unit>
             <trans-unit id="sys_file_storage.filefill.no_missing">
                 <source>No missing files found!</source>
             </trans-unit>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -62,6 +62,17 @@ call_user_func(function () {
                 ],
                 'handler' => \IchHabRecht\Filefill\Resource\Placeholder\PlaceholderResource::class,
             ],
+            'ascii' => [
+                'title' => 'LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.ascii',
+                'config' => [
+                    'label' => 'LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.ascii',
+                    'config' => [
+                        'type' => 'check',
+                        'default' => '1',
+                    ],
+                ],
+                'handler' => \IchHabRecht\Filefill\Resource\Ascii\AsciiResource::class,
+            ],
         ],
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['resourceHandler']
     );


### PR DESCRIPTION
Add new resources handler 'ascii', to fake content of ascii files such as `*.youtube` and `*.vimeo`

Resolves: #47