### PR TITLE
Replace placeholder service

### DIFF
--- a/Classes/Resource/Handler/PlaceholderResource.php
+++ b/Classes/Resource/Handler/PlaceholderResource.php
@@ -43,7 +43,7 @@ class PlaceholderResource implements RemoteResourceInterface
     /**
      * @var string
      */
-    protected $url = 'https://via.placeholder.com/';
+    protected $url = 'https://placehold.co/';
 
     public function __construct($_, RequestFactory $requestFactory = null)
     {


### PR DESCRIPTION
The original placeholder.com service does not exist anymore, use placehold.co as a drop-in replacement instead.

Fixes #74