### PR TITLE
Remove use of TCEForms key in FlexForm configs

### DIFF
--- a/Classes/EventListener/FlexFormDataStructureParsedEventListener.php
+++ b/Classes/EventListener/FlexFormDataStructureParsedEventListener.php
@@ -43,9 +43,7 @@ class FlexFormDataStructureParsedEventListener
 
             $dataStructure['sheets']['sDEF']['ROOT']['el']['resources']['el'][$resource] = [
                 'el' => [
-                    $resource => [
-                        'TCEforms' => $configuration['config'],
-                    ],
+                    $resource => $configuration['config'],
                 ],
                 'title' => $configuration['title'],
                 'type' => 'array',

--- a/Classes/EventListener/FlexFormDataStructureParsedEventListener.php
+++ b/Classes/EventListener/FlexFormDataStructureParsedEventListener.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IchHabRecht\Filefill\EventListener;
+
+/*
+ * This file is part of the TYPO3 extension filefill.
+ *
+ * (c) Nicole Cordes <typo3@cordes.co>
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureParsedEvent;
+
+class FlexFormDataStructureParsedEventListener
+{
+    public function __invoke(AfterFlexFormDataStructureParsedEvent $event)
+    {
+        $identifier = $event->getIdentifier();
+        if ($identifier['tableName'] !== 'sys_file_storage'
+            || $identifier['fieldName'] !== 'tx_filefill_resources'
+        ) {
+            return;
+        }
+
+        $dataStructure = $event->getDataStructure();
+        $dataStructure['sheets']['sDEF']['ROOT']['el']['resources']['el'] = [];
+
+        foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['resourceHandler'] ?? [] as $resource => $configuration) {
+            if (empty($configuration['title'])
+                || empty($configuration['config'])
+                || empty($configuration['handler'])
+            ) {
+                continue;
+            }
+
+            $dataStructure['sheets']['sDEF']['ROOT']['el']['resources']['el'][$resource] = [
+                'el' => [
+                    $resource => [
+                        'TCEforms' => $configuration['config'],
+                    ],
+                ],
+                'title' => $configuration['title'],
+                'type' => 'array',
+            ];
+        }
+
+        $event->setDataStructure($dataStructure);
+    }
+}

--- a/Classes/Form/Element/ShowMissingFiles.php
+++ b/Classes/Form/Element/ShowMissingFiles.php
@@ -17,6 +17,7 @@ namespace IchHabRecht\Filefill\Form\Element;
  * LICENSE file that was distributed with this source code.
  */
 
+use Doctrine\DBAL\FetchMode;
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
 use TYPO3\CMS\Backend\Form\NodeFactory;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -68,7 +69,7 @@ class ShowMissingFiles extends AbstractFormElement
                 )
             )
             ->execute()
-            ->fetchColumn(0);
+            ->fetch(FetchMode::NUMERIC)[0] ?? 0;
 
         $html = [];
         $html[] = '<div class="form-control-wrap">';

--- a/Classes/Hooks/FlexFormToolsHook.php
+++ b/Classes/Hooks/FlexFormToolsHook.php
@@ -37,14 +37,14 @@ class FlexFormToolsHook
                 continue;
             }
 
+            $elementConfig = $configuration['config'];
+
             $dataStructure['sheets']['sDEF']['ROOT']['el']['resources']['el'][$resource] = [
-                'el' => [
-                    $resource => [
-                        'TCEforms' => $configuration['config'],
-                    ],
-                ],
                 'title' => $configuration['title'],
                 'type' => 'array',
+                'el' => [
+                    $resource => $elementConfig,
+                ],
             ];
         }
 

--- a/Configuration/FlexForms/Resources.xml
+++ b/Configuration/FlexForms/Resources.xml
@@ -2,9 +2,7 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.resources</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.resources</sheetTitle>
                 <type>array</type>
                 <el>
                     <resources>

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,7 +16,13 @@ services:
             -   name: event.listener
                 identifier: 'filefillFileProcessingEventEventListener'
                 event: TYPO3\CMS\Core\Resource\Event\BeforeFileProcessingEvent
-                
+
+    IchHabRecht\Filefill\EventListener\FlexFormDataStructureParsedEventListener:
+        tags:
+            -   name: event.listener
+                identifier: 'filefillFlexFormDataStructureParsedEventListener'
+                event: TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureParsedEvent
+
     IchHabRecht\Filefill\Command\DeleteCommand:
         tags:
             - name: 'console.command'


### PR DESCRIPTION
See TYPO3 core change [97126](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97126-RemoveTCEformsArrayKeyInFlexForm.html).

Resolves: #72 