### PR TITLE
[BUGFIX] Fix undefined array key warning

### DIFF
--- a/Classes/EventListener/FlexFormDataStructureParsedEventListener.php
+++ b/Classes/EventListener/FlexFormDataStructureParsedEventListener.php
@@ -24,7 +24,7 @@ class FlexFormDataStructureParsedEventListener
     public function __invoke(AfterFlexFormDataStructureParsedEvent $event)
     {
         $identifier = $event->getIdentifier();
-        if ($identifier['tableName'] !== 'sys_file_storage'
+        if (($identifier['tableName'] ?? '') !== 'sys_file_storage'
             || $identifier['fieldName'] !== 'tx_filefill_resources'
         ) {
             return;


### PR DESCRIPTION
In some cases, the DS identifier may not have an array key `tableName`.

This is the case, for example, with a gridelements identifier with type `gridelements-dummy` in `EXT:gridelements/Classes/Hooks/TtContentFlexForm.php`