### PR TITLE
Dynamically calculate relative path in GifBuilder

### DIFF
--- a/Classes/Imaging/GifBuilder.php
+++ b/Classes/Imaging/GifBuilder.php
@@ -3,40 +3,18 @@ namespace IchHabRecht\Filefill\Imaging;
 
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
 class GifBuilder extends \TYPO3\CMS\Frontend\Imaging\GifBuilder
 {
     public function fileName($pre)
     {
         $fileName = parent::fileName($pre);
-        $absoluteVarPath = Environment::getVarPath(); // e.g. "/var/www/html/var"
-        $publicPath = Environment::getPublicPath();    // e.g. "/var/www/html/public"
+        $absoluteVarPath = Environment::getVarPath();
+        $publicPath = Environment::getPublicPath();
 
         // Calculate the relative path from the public directory to the var directory:
-        if (strpos($absoluteVarPath, $publicPath) === 0) {
-            // Case 1: var is inside public (e.g. public/var)
-            $relativeVarPath = ltrim(substr($absoluteVarPath, strlen($publicPath)), '/');
-        } else {
-            // Case 2: var is outside public (typical for Composer installations)
-            $publicParts = explode('/', trim($publicPath, '/'));
-            $varParts = explode('/', trim($absoluteVarPath, '/'));
-            $commonParts = [];
-            $max = min(count($publicParts), count($varParts));
-            for ($i = 0; $i < $max; $i++) {
-                if ($publicParts[$i] === $varParts[$i]) {
-                    $commonParts[] = $publicParts[$i];
-                } else {
-                    break;
-                }
-            }
-            $levelsUp = count($publicParts) - count($commonParts);
-            $relativePath = str_repeat('../', $levelsUp);
-            $remainder = implode('/', array_slice($varParts, count($commonParts)));
-            if ($remainder !== '') {
-                $relativePath .= $remainder;
-            }
-            $relativeVarPath = $relativePath;
-        }
+        $relativeVarPath = PathUtility::getRelativePath($publicPath, $absoluteVarPath);
 
         // Ensure that the temporary folder exists (relative to public)
         $absoluteTemporaryPath = $publicPath . '/' . $relativeVarPath . '/transient/';

--- a/Classes/Imaging/GifBuilder.php
+++ b/Classes/Imaging/GifBuilder.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace IchHabRecht\Filefill\Imaging;
 
 use TYPO3\CMS\Core\Core\Environment;
@@ -10,11 +9,42 @@ class GifBuilder extends \TYPO3\CMS\Frontend\Imaging\GifBuilder
     public function fileName($pre)
     {
         $fileName = parent::fileName($pre);
-        $temporaryPath = Environment::getVarPath() . '/transient/';
-        if (!is_dir($temporaryPath)) {
-            GeneralUtility::mkdir_deep($temporaryPath);
+        $absoluteVarPath = Environment::getVarPath(); // e.g. "/var/www/html/var"
+        $publicPath = Environment::getPublicPath();    // e.g. "/var/www/html/public"
+
+        // Calculate the relative path from the public directory to the var directory:
+        if (strpos($absoluteVarPath, $publicPath) === 0) {
+            // Case 1: var is inside public (e.g. public/var)
+            $relativeVarPath = ltrim(substr($absoluteVarPath, strlen($publicPath)), '/');
+        } else {
+            // Case 2: var is outside public (typical for Composer installations)
+            $publicParts = explode('/', trim($publicPath, '/'));
+            $varParts = explode('/', trim($absoluteVarPath, '/'));
+            $commonParts = [];
+            $max = min(count($publicParts), count($varParts));
+            for ($i = 0; $i < $max; $i++) {
+                if ($publicParts[$i] === $varParts[$i]) {
+                    $commonParts[] = $publicParts[$i];
+                } else {
+                    break;
+                }
+            }
+            $levelsUp = count($publicParts) - count($commonParts);
+            $relativePath = str_repeat('../', $levelsUp);
+            $remainder = implode('/', array_slice($varParts, count($commonParts)));
+            if ($remainder !== '') {
+                $relativePath .= $remainder;
+            }
+            $relativeVarPath = $relativePath;
         }
 
-        return $temporaryPath . basename($fileName);
+        // Ensure that the temporary folder exists (relative to public)
+        $absoluteTemporaryPath = $publicPath . '/' . $relativeVarPath . '/transient/';
+        if (!is_dir($absoluteTemporaryPath)) {
+            GeneralUtility::mkdir_deep($absoluteTemporaryPath);
+        }
+
+        // Return: the relative path (from the public directory) to the temporary image
+        return $relativeVarPath . '/transient/' . basename($fileName);
     }
 }


### PR DESCRIPTION
This pull request addresses #83 . In Composer-based installations, the `var` directory is located one level above the `public` folder, whereas in classic installations it resides within `public`. Currently, the extension uses `Environment::getVarPath()` to get an absolute path, which causes TYPO3’s core to prepend the public path. This results in an incorrect file path like:  

```
/var/www/html/public//var/...
```  

To resolve this, I modified the `fileName()` method in `Imaging/GifBuilder.php` to dynamically calculate the relative path from the `public` directory to the `var` directory. The approach works as follows:

- **Case 1:** If the var directory is inside `public`, the code simply strips the public part from the absolute var path.
- **Case 2:** If the var directory is outside `public` (typical for Composer installations), it calculates the number of directory levels to go up (`../`) and appends the remaining var path.
- Finally, the method returns the relative path (from the public directory) to the temporary folder where the GIF is stored. This allows TYPO3 to correctly prepend the public path without duplicating it.

This change ensures that Filefill works correctly across all TYPO3 installations and versions by providing a correct relative path for the GIF builder output. Please review the changes and let me know if further adjustments are needed.