### PR TITLE
[TASK] Ensure compatibility to PHP 8.4

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,6 +1,6 @@
 name: 🏃 dev tests
 
-on: [ push, pull_request ]
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
     compute:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: 🏃 tests
 
-on: [ push, pull_request, workflow_call ]
+on: [ push, pull_request, workflow_call, workflow_dispatch ]
 
 jobs:
     compute:

--- a/Classes/Command/DeleteCommand.php
+++ b/Classes/Command/DeleteCommand.php
@@ -23,7 +23,7 @@ class DeleteCommand extends AbstractCommand
      */
     protected $languageService;
 
-    public function __construct(string $name = null, FileRepository $fileRepository = null, $languageService = null)
+    public function __construct(?string $name = null, ?FileRepository $fileRepository = null, $languageService = null)
     {
         parent::__construct($name);
 

--- a/Classes/Command/ResetCommand.php
+++ b/Classes/Command/ResetCommand.php
@@ -24,7 +24,7 @@ class ResetCommand extends AbstractCommand
      */
     protected $fileRepository;
 
-    public function __construct(string $name = null, Connection $connection = null, FileRepository $fileRepository = null)
+    public function __construct(?string $name = null, ?Connection $connection = null, ?FileRepository $fileRepository = null)
     {
         parent::__construct($name);
 

--- a/Classes/Form/Element/ShowDeleteFiles.php
+++ b/Classes/Form/Element/ShowDeleteFiles.php
@@ -45,7 +45,7 @@ class ShowDeleteFiles extends AbstractFormElement
      * @param FileRepository|null $fileRepository
      * @param LanguageService|null $languageService
      */
-    public function __construct(NodeFactory $nodeFactory, array $data, FileRepository $fileRepository = null, $languageService = null)
+    public function __construct(NodeFactory $nodeFactory, array $data, ?FileRepository $fileRepository = null, $languageService = null)
     {
         parent::__construct($nodeFactory, $data);
         $this->fileRepository = $fileRepository ?: GeneralUtility::makeInstance(FileRepository::class);

--- a/Classes/Hooks/DeleteFiles.php
+++ b/Classes/Hooks/DeleteFiles.php
@@ -29,7 +29,7 @@ class DeleteFiles
     protected $fileRepository;
 
     public function __construct(
-        FileRepository $fileRepository = null
+        ?FileRepository $fileRepository = null
     ) {
         $this->fileRepository = $fileRepository ?: GeneralUtility::makeInstance(FileRepository::class);
     }

--- a/Classes/Repository/FileRepository.php
+++ b/Classes/Repository/FileRepository.php
@@ -42,9 +42,9 @@ class FileRepository
     protected $resourceFactory;
 
     public function __construct(
-        Connection $connection = null,
-        ProcessedFileRepository $processedFileRepository = null,
-        ResourceFactory $resourceFactory = null
+        ?Connection $connection = null,
+        ?ProcessedFileRepository $processedFileRepository = null,
+        ?ResourceFactory $resourceFactory = null
     ) {
         $this->connection = $connection ?: GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('sys_file');
         $this->processedFileRepository = $processedFileRepository ?: GeneralUtility::makeInstance(ProcessedFileRepository::class);

--- a/Classes/Resource/Handler/DomainResource.php
+++ b/Classes/Resource/Handler/DomainResource.php
@@ -79,7 +79,7 @@ class DomainResource implements RemoteResourceInterface
 
             return @fopen($fileName, 'r') ?: $this->requestFactory->request($fileName)->getBody()->getContents();
         } catch (RequestException $e) {
-            return false;
+            return '';
         }
     }
 }

--- a/Classes/Resource/Handler/DomainResource.php
+++ b/Classes/Resource/Handler/DomainResource.php
@@ -41,7 +41,7 @@ class DomainResource implements RemoteResourceInterface
      * @param string $configuration
      * @param RequestFactory $requestFactory
      */
-    public function __construct($configuration, RequestFactory $requestFactory = null)
+    public function __construct($configuration, ?RequestFactory $requestFactory = null)
     {
         $this->requestFactory = $requestFactory ?: GeneralUtility::makeInstance(RequestFactory::class);
         $urlParts = parse_url((string)$configuration);
@@ -55,7 +55,7 @@ class DomainResource implements RemoteResourceInterface
      * @param FileInterface|null $fileObject
      * @return bool
      */
-    public function hasFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function hasFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         try {
             $response = $this->requestFactory->request($this->url . ltrim($filePath, '/'), 'HEAD');
@@ -72,7 +72,7 @@ class DomainResource implements RemoteResourceInterface
      * @param FileInterface|null $fileObject
      * @return resource|string
      */
-    public function getFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function getFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         try {
             $fileName = $this->url . ltrim($filePath, '/');

--- a/Classes/Resource/Handler/ImageBuilderResource.php
+++ b/Classes/Resource/Handler/ImageBuilderResource.php
@@ -61,7 +61,7 @@ class ImageBuilderResource implements RemoteResourceInterface
      * @param FileInterface $fileObject
      * @return bool
      */
-    public function hasFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function hasFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         return $GLOBALS['TYPO3_CONF_VARS']['GFX']['gdlib']
             && $fileObject instanceof FileInterface
@@ -74,7 +74,7 @@ class ImageBuilderResource implements RemoteResourceInterface
      * @param FileInterface $fileObject
      * @return string
      */
-    public function getFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function getFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         $content = '';
 

--- a/Classes/Resource/Handler/PlaceholdResource.php
+++ b/Classes/Resource/Handler/PlaceholdResource.php
@@ -85,7 +85,7 @@ class PlaceholdResource implements RemoteResourceInterface
 
             return $response->getBody()->getContents();
         } catch (RequestException $e) {
-            return false;
+            return '';
         }
     }
 }

--- a/Classes/Resource/Handler/PlaceholdResource.php
+++ b/Classes/Resource/Handler/PlaceholdResource.php
@@ -48,7 +48,7 @@ class PlaceholdResource implements RemoteResourceInterface
      */
     protected $url = 'https://placehold.co/';
 
-    public function __construct($_, RequestFactory $requestFactory = null)
+    public function __construct($_, ?RequestFactory $requestFactory = null)
     {
         $this->requestFactory = $requestFactory ?: GeneralUtility::makeInstance(RequestFactory::class);
     }
@@ -59,7 +59,7 @@ class PlaceholdResource implements RemoteResourceInterface
      * @param FileInterface $fileObject
      * @return bool
      */
-    public function hasFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function hasFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         return $fileObject instanceof FileInterface
             && in_array($fileObject->getExtension(), $this->allowedFileExtensions, true);
@@ -71,7 +71,7 @@ class PlaceholdResource implements RemoteResourceInterface
      * @param FileInterface $fileObject
      * @return string
      */
-    public function getFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function getFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         try {
             $fileExtension = $fileObject->getExtension();

--- a/Classes/Resource/Handler/PlaceholderResource.php
+++ b/Classes/Resource/Handler/PlaceholderResource.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Core\Http\RequestFactory;
 
 class PlaceholderResource extends PlaceholdResource
 {
-    public function __construct($_, RequestFactory $requestFactory = null)
+    public function __construct($_, ?RequestFactory $requestFactory = null)
     {
         trigger_error(
             'As the service placeholder.com was closed down, using this class is deprecated. Please use the' .

--- a/Classes/Resource/Handler/StaticFileResource.php
+++ b/Classes/Resource/Handler/StaticFileResource.php
@@ -52,7 +52,7 @@ class StaticFileResource implements RemoteResourceInterface
         $this->configuration = $this->prepareConfiguration($configuration);
     }
 
-    public function hasFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function hasFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         return true;
     }
@@ -63,7 +63,7 @@ class StaticFileResource implements RemoteResourceInterface
      * @param FileInterface $fileObject
      * @return string
      */
-    public function getFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function getFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         return $this->getFileContent($fileIdentifier, $this->configuration);
     }

--- a/Classes/Resource/Handler/SysDomainResource.php
+++ b/Classes/Resource/Handler/SysDomainResource.php
@@ -38,7 +38,7 @@ class SysDomainResource implements RemoteResourceInterface
      * @param string $configuration
      * @param DomainResourceRepository $domainResourceRepository
      */
-    public function __construct($configuration, DomainResourceRepository $domainResourceRepository = null)
+    public function __construct($configuration, ?DomainResourceRepository $domainResourceRepository = null)
     {
         if ($domainResourceRepository === null) {
             $domainResourceRepository = GeneralUtility::makeInstance(DomainResourceRepository::class);
@@ -52,7 +52,7 @@ class SysDomainResource implements RemoteResourceInterface
      * @param FileInterface|null $fileObject
      * @return bool
      */
-    public function hasFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function hasFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         if (!isset(static::$fileIdentifierCache[$fileIdentifier])) {
             static::$fileIdentifierCache[$fileIdentifier] = null;
@@ -73,7 +73,7 @@ class SysDomainResource implements RemoteResourceInterface
      * @param FileInterface|null $fileObject
      * @return string
      */
-    public function getFile($fileIdentifier, $filePath, FileInterface $fileObject = null)
+    public function getFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null)
     {
         return static::$fileIdentifierCache[$fileIdentifier]->getFile($fileIdentifier, $filePath);
     }

--- a/Classes/Resource/RemoteResourceCollection.php
+++ b/Classes/Resource/RemoteResourceCollection.php
@@ -61,7 +61,7 @@ class RemoteResourceCollection implements LoggerAwareInterface
      * @param ResourceFactory|null $resourceFactory
      * @param FileRepository|null $fileRepository
      */
-    public function __construct(array $resources, ResourceFactory $resourceFactory = null, FileRepository $fileRepository = null)
+    public function __construct(array $resources, ?ResourceFactory $resourceFactory = null, ?FileRepository $fileRepository = null)
     {
         $this->resources = $resources;
         $this->resourceFactory = $resourceFactory ?: GeneralUtility::makeInstance(ResourceFactory::class);

--- a/Classes/Resource/RemoteResourceInterface.php
+++ b/Classes/Resource/RemoteResourceInterface.php
@@ -27,7 +27,7 @@ interface RemoteResourceInterface
      * @param FileInterface|null $fileObject
      * @return bool
      */
-    public function hasFile($fileIdentifier, $filePath, FileInterface $fileObject = null);
+    public function hasFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null);
 
     /**
      * @param string $fileIdentifier
@@ -35,5 +35,5 @@ interface RemoteResourceInterface
      * @param FileInterface|null $fileObject
      * @return resource|string
      */
-    public function getFile($fileIdentifier, $filePath, FileInterface $fileObject = null);
+    public function getFile($fileIdentifier, $filePath, ?FileInterface $fileObject = null);
 }


### PR DESCRIPTION
This PR is supposed to ensure the compatibility to PHP 8.4 by making implicitly marked function parameters explicitly nullable, thus fixing #94 

Commits:

- [BUGFIX] Return empty string instead of false on request exception - Fixed error handling in DomainResource and PlaceholdResource to return consistent string types
- [CLEANUP] Update constructor parameter types to nullable - Enhanced type safety across 13 classes with proper nullable parameter declarations

Changes:

- Bug Fix: Changed RequestException handling to return empty string instead of false
- Type Safety: Updated constructor parameters to use nullable types (?Type)
- Impact: No breaking changes, improved reliability and consistency