### PR TITLE
[TASK] Stabilize functional tests against Wikimedia rate limiting

### DIFF
--- a/Tests/Functional/AbstractFunctionalTestCase.php
+++ b/Tests/Functional/AbstractFunctionalTestCase.php
@@ -32,6 +32,13 @@ class AbstractFunctionalTestCase extends FunctionalTestCase
         ];
 
         $this->configurationToUseInTestInstance = [
+            // Wikimedia throttles requests with a generic User-Agent from cloud/CI
+            // IP ranges, see https://w.wiki/4wJS
+            'HTTP' => [
+                'headers' => [
+                    'User-Agent' => 'TYPO3-filefill-tests/1.0 (+https://github.com/IchHabRecht/filefill)',
+                ],
+            ],
             'EXTCONF' => [
                 'filefill' => [
                     'storages' => [

--- a/Tests/Functional/FilefillTest.php
+++ b/Tests/Functional/FilefillTest.php
@@ -60,6 +60,12 @@ class FilefillTest extends AbstractFunctionalTestCase
         $this->assertStringNotEqualsFile($this->getAbsoluteFilePath($domainResourcePath), '');
 
         $rows = $this->fileRepository->findByIdentifier('domain', 2);
+        if ($rows === []) {
+            // Wikimedia may have started throttling between the initial probe
+            // and the actual fetch, making the placehold resource serve the
+            // file instead - re-check before failing
+            $this->skipTestIfDomainResourceIsNotReachable();
+        }
         $this->assertCount(1, $rows);
     }
 
@@ -167,7 +173,7 @@ class FilefillTest extends AbstractFunctionalTestCase
     {
         try {
             $statusCode = GeneralUtility::makeInstance(RequestFactory::class)
-                ->request('https://upload.wikimedia.org/wikipedia/commons/5/58/Logo_TYPO3.svg', 'HEAD')
+                ->request('https://upload.wikimedia.org/wikipedia/commons/5/58/Logo_TYPO3.svg')
                 ->getStatusCode();
         } catch (\Throwable $e) {
             $statusCode = 0;

--- a/Tests/Functional/FilefillTest.php
+++ b/Tests/Functional/FilefillTest.php
@@ -18,6 +18,7 @@ namespace IchHabRecht\Filefill\Tests\Functional;
  */
 
 use IchHabRecht\Filefill\Repository\FileRepository;
+use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Domain\Model\File;
@@ -47,6 +48,8 @@ class FilefillTest extends AbstractFunctionalTestCase
      */
     public function fileExistsWithDomainResource()
     {
+        $this->skipTestIfDomainResourceIsNotReachable();
+
         $domainResourcePath = self::STORAGE_FOLDER . '/commons/5/58/Logo_TYPO3.svg';
 
         $file = $this->resourceFactory->getFileObjectFromCombinedIdentifier($domainResourcePath);
@@ -152,5 +155,26 @@ class FilefillTest extends AbstractFunctionalTestCase
         $this->assertFileExists($this->getAbsoluteFilePath($fileResourcePath));
 
         $this->assertStringEqualsFile($this->getAbsoluteFilePath($fileResourcePath), $content);
+    }
+
+    /**
+     * Wikimedia throttles requests from cloud IP ranges (e.g. GitHub Actions
+     * runners), see https://w.wiki/4wJS. As this test asserts that the file
+     * has been fetched by the domain resource, it has to be skipped instead
+     * of falling back to the next configured resource.
+     */
+    protected function skipTestIfDomainResourceIsNotReachable(): void
+    {
+        try {
+            $statusCode = GeneralUtility::makeInstance(RequestFactory::class)
+                ->request('https://upload.wikimedia.org/wikipedia/commons/5/58/Logo_TYPO3.svg', 'HEAD')
+                ->getStatusCode();
+        } catch (\Throwable $e) {
+            $statusCode = 0;
+        }
+
+        if ($statusCode !== 200) {
+            self::markTestSkipped('upload.wikimedia.org is not reachable, status code ' . $statusCode);
+        }
     }
 }


### PR DESCRIPTION
## Problem

The functional test suite fetches real files from `upload.wikimedia.org`. Wikimedia enforces its [robot policy](https://w.wiki/4wJS) for requests coming from cloud IP ranges (such as GitHub Actions runners) and throttles them with `429 Too many requests` / `429 Your request does not comply with our robot policy`.

When the `domain` resource is throttled, the `placehold` fallback serves the file instead. Most tests still pass (they only assert non-empty content), but `FilefillTest::fileExistsWithDomainResource` asserts that the file was fetched by the `domain` resource and fails. This is why the CI on `main` is currently red and PR runs fail intermittently.

## Solution

Two small changes to the test setup only, no production code is touched:

1. **Send a descriptive User-Agent** in the test instance instead of the generic default `TYPO3`, as required by the Wikimedia robot policy.
2. **Skip `fileExistsWithDomainResource` when Wikimedia is not reachable**: the test now probes the remote file with a HEAD request first and calls `markTestSkipped()` when it does not answer with `200`, instead of reporting a false negative. Locally the test still runs and asserts the full behaviour.

Verified on a fork with the same workflows: with both changes all matrix jobs are green ([example run](https://github.com/SvenJuergens/filefill/actions)) — the domain test runs fully when Wikimedia allows it and is skipped transparently when the runner IP is throttled.