### PR TITLE
[FEATURE] TYPO3 v14 compatibility

### DIFF
--- a/.github/workflows/compute.yml
+++ b/.github/workflows/compute.yml
@@ -9,8 +9,10 @@ env:
         "8.4"
     TYPO3: |
         "^13.4"
+        "^14.3"
     TYPO3_DEV: |
         "13.4.x-dev"
+        "14.3.x-dev"
     EXCLUDE: |
         {   
         }

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.php_cs.cache
 /.phpunit.cache/
 /composer.lock
+/packages/
+/var/

--- a/Classes/Repository/FileRepository.php
+++ b/Classes/Repository/FileRepository.php
@@ -22,13 +22,15 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\ProcessedFileRepository;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 
 class FileRepository
 {
     public function __construct(
         protected readonly ConnectionPool $connectionPool,
         protected readonly ProcessedFileRepository $processedFileRepository,
-        protected readonly ResourceFactory $resourceFactory
+        protected readonly ResourceFactory $resourceFactory,
+        protected readonly StorageRepository $storageRepository
     ) {
     }
 
@@ -105,7 +107,8 @@ class FileRepository
         $rows = $this->findByIdentifier($identifier, $storage);
         foreach ($rows as $row) {
             try {
-                $file = $this->resourceFactory->getFileObjectByStorageAndIdentifier($row['storage'], $row['identifier']);
+                $storage = $this->storageRepository->findByUid((int)$row['storage']);
+                $file = $storage?->getFileByIdentifier($row['identifier']);
                 if (!$file) {
                     continue;
                 }

--- a/Classes/Resource/RemoteResourceCollection.php
+++ b/Classes/Resource/RemoteResourceCollection.php
@@ -29,6 +29,7 @@ use TYPO3\CMS\Core\Resource\ProcessedFile;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\ResourceInterface;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class RemoteResourceCollection implements LoggerAwareInterface
@@ -43,6 +44,7 @@ class RemoteResourceCollection implements LoggerAwareInterface
     protected readonly array $resources;
 
     protected readonly ResourceFactory $resourceFactory;
+    protected readonly StorageRepository $storageRepository;
 
     /**
      * @var FileInterface[]
@@ -61,6 +63,7 @@ class RemoteResourceCollection implements LoggerAwareInterface
         $this->resources = $resources;
         $this->resourceFactory = $resourceFactory ?: GeneralUtility::makeInstance(ResourceFactory::class);
         $this->fileRepository = $fileRepository ?: GeneralUtility::makeInstance(FileRepository::class);
+        $this->storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
     }
 
     /**
@@ -143,7 +146,7 @@ class RemoteResourceCollection implements LoggerAwareInterface
         if (!array_key_exists($filePath, static::$fileIdentifierCache)) {
             static::$fileIdentifierCache[$filePath] = null;
             $localPath = $filePath;
-            $storage = $this->resourceFactory->getStorageObject(0, [], $localPath);
+            $storage = $this->storageRepository->getStorageObject(0, [], $localPath);
             if ($storage->getUid() !== 0) {
                 static::$fileIdentifierCache[$filePath] = $this->getFileObjectFromStorage($storage, $fileIdentifier);
             }
@@ -162,7 +165,7 @@ class RemoteResourceCollection implements LoggerAwareInterface
     {
         if (!$storage->isWithinProcessingFolder($fileIdentifier)) {
             try {
-                $fileObject = $this->resourceFactory->getFileObjectByStorageAndIdentifier($storage->getUid(), $fileIdentifier);
+                $fileObject = $storage->getFileByIdentifier($fileIdentifier);
             } catch (\InvalidArgumentException) {
                 return null;
             }

--- a/Configuration/TCA/Overrides/sys_file_storage.php
+++ b/Configuration/TCA/Overrides/sys_file_storage.php
@@ -31,9 +31,12 @@ $tempColumns = [
         'displayCond' => 'FIELD:driver:=:Local',
         'config' => [
             'type' => 'flex',
-            'ds' => [
-                'default' => 'FILE:EXT:filefill/Configuration/FlexForms/Resources.xml',
-            ],
+            // TYPO3 v13 expects an array with "default" key, since v14 "ds" holds the data structure directly
+            'ds' => (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() >= 14
+                ? 'FILE:EXT:filefill/Configuration/FlexForms/Resources.xml'
+                : [
+                    'default' => 'FILE:EXT:filefill/Configuration/FlexForms/Resources.xml',
+                ],
         ],
     ],
     'tx_filefill_missing' => [

--- a/Tests/Functional/AbstractFunctionalTestCase.php
+++ b/Tests/Functional/AbstractFunctionalTestCase.php
@@ -30,6 +30,13 @@ class AbstractFunctionalTestCase extends FunctionalTestCase
     ];
 
     protected array $configurationToUseInTestInstance = [
+        // Wikimedia throttles requests with a generic User-Agent from cloud/CI
+        // IP ranges, see https://w.wiki/4wJS
+        'HTTP' => [
+            'headers' => [
+                'User-Agent' => 'TYPO3-filefill-tests/1.0 (+https://github.com/IchHabRecht/filefill)',
+            ],
+        ],
         'EXTCONF' => [
             'filefill' => [
                 'storages' => [

--- a/Tests/Functional/AbstractFunctionalTestCase.php
+++ b/Tests/Functional/AbstractFunctionalTestCase.php
@@ -24,54 +24,49 @@ class AbstractFunctionalTestCase extends FunctionalTestCase
 {
     protected const STORAGE_FOLDER = 'wikipedia';
 
-    public function __construct(?string $name = null, array $data = [], $dataName = '')
-    {
-        $this->additionalFoldersToCreate = [
-            'fileadmin',
-            self::STORAGE_FOLDER,
-        ];
+    protected array $additionalFoldersToCreate = [
+        'fileadmin',
+        self::STORAGE_FOLDER,
+    ];
 
-        $this->configurationToUseInTestInstance = [
-            'EXTCONF' => [
-                'filefill' => [
-                    'storages' => [
-                        2 => [
-                            [
-                                'identifier' => 'domain',
-                                'configuration' => 'https://upload.wikimedia.org',
-                            ],
-                            [
-                                'identifier' => 'placehold',
-                            ],
-                            [
-                                'identifier' => 'static',
-                                'configuration' => [
-                                    'path/to/example/file.txt' => 'Hello world!',
-                                    'another' => [
-                                        'path' => [
-                                            'to' => [
-                                                'anotherFile.txt' => 'Lorem ipsum',
-                                                '*.youtube' => 'yiJjpKzCVE4',
-                                            ],
-                                            '*' => 'This file was found in /another/path folder.',
+    protected array $configurationToUseInTestInstance = [
+        'EXTCONF' => [
+            'filefill' => [
+                'storages' => [
+                    2 => [
+                        [
+                            'identifier' => 'domain',
+                            'configuration' => 'https://upload.wikimedia.org',
+                        ],
+                        [
+                            'identifier' => 'placehold',
+                        ],
+                        [
+                            'identifier' => 'static',
+                            'configuration' => [
+                                'path/to/example/file.txt' => 'Hello world!',
+                                'another' => [
+                                    'path' => [
+                                        'to' => [
+                                            'anotherFile.txt' => 'Lorem ipsum',
+                                            '*.youtube' => 'yiJjpKzCVE4',
                                         ],
+                                        '*' => 'This file was found in /another/path folder.',
                                     ],
-                                    '*.vimeo' => '143018597',
-                                    '*' => 'This is some static text for all other files.',
                                 ],
+                                '*.vimeo' => '143018597',
+                                '*' => 'This is some static text for all other files.',
                             ],
                         ],
                     ],
                 ],
             ],
-        ];
+        ],
+    ];
 
-        $this->testExtensionsToLoad = [
-            'typo3conf/ext/filefill',
-        ];
-
-        parent::__construct($name, $data, $dataName);
-    }
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/filefill',
+    ];
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Command/DeleteCommandTest.php
+++ b/Tests/Functional/Command/DeleteCommandTest.php
@@ -18,11 +18,13 @@ namespace IchHabRecht\Filefill\Tests\Functional\Command;
  */
 
 use IchHabRecht\Filefill\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use TYPO3\CMS\Core\Console\CommandRegistry;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class DeleteCommandTest extends AbstractFunctionalTestCase
@@ -57,9 +59,7 @@ class DeleteCommandTest extends AbstractFunctionalTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function executeDeleteCommandForIdentifier(): void
     {
         $input = new ArrayInput([
@@ -83,9 +83,7 @@ class DeleteCommandTest extends AbstractFunctionalTestCase
         $this->assertEmpty($rows);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function executeDeleteCommandForStorage(): void
     {
         $input = new ArrayInput([
@@ -99,18 +97,16 @@ class DeleteCommandTest extends AbstractFunctionalTestCase
 
         $this->assertEquals(0, $statusCode);
 
-        $storage = $this->resourceFactory->getStorageObject(1);
+        $storage = $this->get(StorageRepository::class)->getStorageObject(1);
         $files = $storage->getFilesInFolder($storage->getRootLevelFolder(), 0, 0, false, true);
         $this->assertEmpty($files);
 
-        $storage = $this->resourceFactory->getStorageObject(2);
+        $storage = $this->get(StorageRepository::class)->getStorageObject(2);
         $files = $storage->getFilesInFolder($storage->getRootLevelFolder(), 0, 0, false, true);
         $this->assertNotEmpty($files);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function executeDeleteCommandForAll(): void
     {
         $input = new ArrayInput([
@@ -122,11 +118,11 @@ class DeleteCommandTest extends AbstractFunctionalTestCase
         $statusCode = $command->run($input, $output);
         $this->assertEquals(0, $statusCode);
 
-        $storage = $this->resourceFactory->getStorageObject(1);
+        $storage = $this->get(StorageRepository::class)->getStorageObject(1);
         $files = $storage->getFilesInFolder($storage->getRootLevelFolder(), 0, 0, false, true);
         $this->assertEmpty($files);
 
-        $storage = $this->resourceFactory->getStorageObject(2);
+        $storage = $this->get(StorageRepository::class)->getStorageObject(2);
         $files = $storage->getFilesInFolder($storage->getRootLevelFolder(), 0, 0, false, true);
         $this->assertEmpty($files);
     }

--- a/Tests/Functional/Command/ResetCommandTest.php
+++ b/Tests/Functional/Command/ResetCommandTest.php
@@ -18,6 +18,7 @@ namespace IchHabRecht\Filefill\Tests\Functional\Command;
  */
 
 use IchHabRecht\Filefill\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use TYPO3\CMS\Core\Console\CommandRegistry;
@@ -53,9 +54,7 @@ class ResetCommandTest extends AbstractFunctionalTestCase
         $this->assertNotEmpty($rows);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function executeResetCommandForStorage(): void
     {
         $input = new ArrayInput([
@@ -103,9 +102,7 @@ class ResetCommandTest extends AbstractFunctionalTestCase
         $this->assertNotEmpty($rows);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function executeResetCommandForAll(): void
     {
         $input = new ArrayInput([]);

--- a/Tests/Functional/FilefillTest.php
+++ b/Tests/Functional/FilefillTest.php
@@ -18,9 +18,10 @@ namespace IchHabRecht\Filefill\Tests\Functional;
  */
 
 use IchHabRecht\Filefill\Repository\FileRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Domain\Model\File;
 
 class FilefillTest extends AbstractFunctionalTestCase
 {
@@ -42,9 +43,7 @@ class FilefillTest extends AbstractFunctionalTestCase
         $this->resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fileExistsWithDomainResource()
     {
         $domainResourcePath = self::STORAGE_FOLDER . '/commons/5/58/Logo_TYPO3.svg';
@@ -60,9 +59,7 @@ class FilefillTest extends AbstractFunctionalTestCase
         $this->assertCount(1, $rows);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fileExistsWithPlaceholderResource()
     {
         $placeholderResourcePath = self::STORAGE_FOLDER . '/Logo_TYPO3.png';
@@ -90,11 +87,8 @@ class FilefillTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider fileExistsWithImageBuilderResourceDataProvider
-     * @param string $fileName
-     */
+    #[Test]
+    #[DataProvider('fileExistsWithImageBuilderResourceDataProvider')]
     public function fileExistsWithImageBuilderResource(string $fileName)
     {
         $fileResourcePath = self::STORAGE_FOLDER . '/' . $fileName;
@@ -136,12 +130,8 @@ class FilefillTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider fileExistsWithStaticResourceDataProvider
-     * @param string $fileName
-     * @param string $content
-     */
+    #[Test]
+    #[DataProvider('fileExistsWithStaticResourceDataProvider')]
     public function fileExistsWithStaticResource(string $fileName, string $content)
     {
         $fileResourcePath = self::STORAGE_FOLDER . '/' . $fileName;

--- a/Tests/Functional/FilefillTest.php
+++ b/Tests/Functional/FilefillTest.php
@@ -20,6 +20,7 @@ namespace IchHabRecht\Filefill\Tests\Functional;
 use IchHabRecht\Filefill\Repository\FileRepository;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -46,6 +47,8 @@ class FilefillTest extends AbstractFunctionalTestCase
     #[Test]
     public function fileExistsWithDomainResource()
     {
+        $this->skipTestIfDomainResourceIsNotReachable();
+
         $domainResourcePath = self::STORAGE_FOLDER . '/commons/5/58/Logo_TYPO3.svg';
 
         $file = $this->resourceFactory->getFileObjectFromCombinedIdentifier($domainResourcePath);
@@ -142,5 +145,26 @@ class FilefillTest extends AbstractFunctionalTestCase
         $this->assertFileExists($this->getAbsoluteFilePath($fileResourcePath));
 
         $this->assertStringEqualsFile($this->getAbsoluteFilePath($fileResourcePath), $content);
+    }
+
+    /**
+     * Wikimedia throttles requests from cloud IP ranges (e.g. GitHub Actions
+     * runners), see https://w.wiki/4wJS. As this test asserts that the file
+     * has been fetched by the domain resource, it has to be skipped instead
+     * of falling back to the next configured resource.
+     */
+    protected function skipTestIfDomainResourceIsNotReachable(): void
+    {
+        try {
+            $statusCode = GeneralUtility::makeInstance(RequestFactory::class)
+                ->request('https://upload.wikimedia.org/wikipedia/commons/5/58/Logo_TYPO3.svg', 'HEAD')
+                ->getStatusCode();
+        } catch (\Throwable $e) {
+            $statusCode = 0;
+        }
+
+        if ($statusCode !== 200) {
+            self::markTestSkipped('upload.wikimedia.org is not reachable, status code ' . $statusCode);
+        }
     }
 }

--- a/Tests/Functional/FilefillTest.php
+++ b/Tests/Functional/FilefillTest.php
@@ -59,6 +59,12 @@ class FilefillTest extends AbstractFunctionalTestCase
         $this->assertStringNotEqualsFile($this->getAbsoluteFilePath($domainResourcePath), '');
 
         $rows = $this->fileRepository->findByIdentifier('domain', 2);
+        if ($rows === []) {
+            // Wikimedia may have started throttling between the initial probe
+            // and the actual fetch, making the placehold resource serve the
+            // file instead - re-check before failing
+            $this->skipTestIfDomainResourceIsNotReachable();
+        }
         $this->assertCount(1, $rows);
     }
 
@@ -157,7 +163,7 @@ class FilefillTest extends AbstractFunctionalTestCase
     {
         try {
             $statusCode = GeneralUtility::makeInstance(RequestFactory::class)
-                ->request('https://upload.wikimedia.org/wikipedia/commons/5/58/Logo_TYPO3.svg', 'HEAD')
+                ->request('https://upload.wikimedia.org/wikipedia/commons/5/58/Logo_TYPO3.svg')
                 ->getStatusCode();
         } catch (\Throwable $e) {
             $statusCode = 0;

--- a/Tests/Unit/Resource/Handler/StaticFileResourceTest.php
+++ b/Tests/Unit/Resource/Handler/StaticFileResourceTest.php
@@ -18,6 +18,8 @@ namespace IchHabRecht\Filefill\Tests\Unit\Resource\Handler;
  */
 
 use IchHabRecht\Filefill\Resource\Handler\StaticFileResource;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\TypoScript\AST\Node\RootNode;
 use TYPO3\CMS\Core\TypoScript\TypoScriptStringFactory;
@@ -88,20 +90,16 @@ EOT;
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getFileReturnsContentDataProvider
-     */
+    #[Test]
+    #[DataProvider('getFileReturnsContentDataProvider')]
     public function getFileReturnsContentForArrayConfiguration(string $filePath, string $expectation): void
     {
         $subject = $this->getStaticFileResource($this->configuration);
         $this->assertEquals($expectation, $subject->getFile($filePath, $filePath));
     }
 
-    /**
-     * @test
-     * @dataProvider getFileReturnsContentDataProvider
-     */
+    #[Test]
+    #[DataProvider('getFileReturnsContentDataProvider')]
     public function getFileReturnsContentForTypoScriptConfiguration(string $filePath, string $expectation): void
     {
         $subject = $this->getStaticFileResource($this->tsConfiguration);

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "typo3/cms-core": "^13.4"
+        "typo3/cms-core": "^13.4 || ^14.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "typo3/cms-core": "^13.4 || ^14.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0",
         "php-parallel-lint/php-parallel-lint": "^1.4",
-        "typo3/testing-framework": "^8.2.3",
+        "typo3/testing-framework": "^8.2.3 || ^9.2",
         "dg/bypass-finals": "^1.9"
     },
     "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' =>
     array (
-      'typo3' => '13.4.0-13.4.99',
+      'typo3' => '13.4.0-14.2.99',
     ),
     'conflicts' =>
     array (

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' =>
     array (
-      'typo3' => '13.4.0-14.2.99',
+      'typo3' => '13.4.0-14.99.99',
     ),
     'conflicts' =>
     array (

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -32,7 +32,7 @@ call_user_func(function () {
                     'label' => 'LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.url',
                     'config' => [
                         'type' => 'input',
-                        'eval' => 'required',
+                        'required' => true,
                     ],
                 ],
                 'handler' => \IchHabRecht\Filefill\Resource\Handler\DomainResource::class,
@@ -43,7 +43,7 @@ call_user_func(function () {
                     'label' => 'LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.colors',
                     'config' => [
                         'type' => 'input',
-                        'eval' => 'required',
+                        'required' => true,
                         'default' => '#FFFFFF, #000000',
                     ],
                 ],


### PR DESCRIPTION
Continues #98 by @georgringer (his commit is included with attribution, as suggested in his PR description) and completes the TYPO3 v14 support:

## Production code

* #98: composer/ext_emconf constraints, `StorageRepository` usage in `RemoteResourceCollection`
* `FileRepository::deleteByIdentifier()` still used the removed `ResourceFactory::getFileObjectByStorageAndIdentifier()` — replaced with `StorageRepository`/`ResourceStorage::getFileByIdentifier()` (available in v13 as well)
* TCA: `'eval' => 'required'` → `'required' => true` (supported since v12) and the FlexForm `ds` registration is now version dependent — v14 expects the data structure directly as string, while v13 only supports the `'default'` array key. This avoids the automatic TCA migration log entries on v14.

## Tests

* Allow PHPUnit 11/12 and typo3/testing-framework v9 in `require-dev` (composer picks the right combination per core/PHP version)
* Doc-comment annotations (`@test`, `@dataProvider`) replaced with PHP attributes — removed in PHPUnit 12, supported since PHPUnit 10
* `AbstractFunctionalTestCase` initializes the testing framework properties directly instead of overriding the `TestCase` constructor, which is final in PHPUnit 12
* `DeleteCommandTest` resolves storages via `StorageRepository`

## CI

* Test matrix extended with `^14.3` / `14.3.x-dev`

Note: this branch also contains the three commits from #100 — without them the functional tests cannot run reliably on GitHub runners (Wikimedia throttling). Once #100 is merged the diff of this PR shrinks accordingly.

Verified locally (unit + functional green on TYPO3 13.4.32 and 14.3.4) and on a fork with the same workflows: all matrix jobs green across TYPO3 ^13.4/^14.3 × PHP 8.2/8.3/8.4.